### PR TITLE
[LUCEE_FIX_2] Obtain id of DCStack from the pool of strings in DatasourceConnectionPool.getDCStack()

### DIFF
--- a/core/src/main/java/lucee/runtime/db/DatasourceConnectionPool.java
+++ b/core/src/main/java/lucee/runtime/db/DatasourceConnectionPool.java
@@ -308,7 +308,7 @@ public class DatasourceConnectionPool {
 	}
 
 	private DCStack getDCStack(DataSource datasource, String user, String pass) {
-		String id = createId(datasource, user, pass);
+		String id = createId(datasource, user, pass).intern();
 		synchronized (id) {
 			DCStack stack = dcs.get(id);
 


### PR DESCRIPTION
[wik](https://github.com/piotr87/Lucee/wiki/%5BLUCEE_FIX_2%5D-Obtain-id-of-DCStack-from-the-pool-of-strings-in-DatasourceConnectionPool.getDCStack())